### PR TITLE
Fixed issue #56

### DIFF
--- a/main.js
+++ b/main.js
@@ -102,7 +102,7 @@ function createWindow () {
     height: 900,
     minWidth: 800,
     minHeight: 640,
-    icon: process.platform === 'linux' && path.join(__dirname, '/images/appicon.png'),
+    icon: process.platform === 'linux' && path.join(__dirname, '/build/icon.png'),
     webPreferences: {
       nodeIntegration: true
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "glyphr-studio-desktop",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
       "build/*",
       "main.js",
       "renderer.*",
-      "node_modules/**/*",
       "package.json"
     ],
     "mac": {
@@ -62,7 +61,7 @@
   "scripts": {
     "start": "node build.js && electron .",
     "pack": "node build.js && electron-builder --dir",
-    "dist": "node build.js && electron-builder --macos --windows --linux",
+    "dist": "node build.js && electron-builder --linux",
     "test": "standard"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "productName": "Glyphr Studio",
     "files": [
       "build/*",
-      "main.js"
+      "main.js",
+      "renderer.*",
+      "package.json"
     ],
     "mac": {
       "category": "public.app-category.graphics-design"

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "productName": "Glyphr Studio",
     "files": [
       "build/*",
-      "main.js",
-      "renderer.*",
-      "package.json"
+      "main.js"
     ],
     "mac": {
       "category": "public.app-category.graphics-design"
@@ -61,7 +59,7 @@
   "scripts": {
     "start": "node build.js && electron .",
     "pack": "node build.js && electron-builder --dir",
-    "dist": "node build.js && electron-builder --linux",
+    "dist": "node build.js && electron-builder --macos --windows --linux",
     "test": "standard"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,13 @@
   "build": {
     "appId": "com.glyphrstudio.desktop",
     "productName": "Glyphr Studio",
+    "files": [
+      "build/*",
+      "main.js",
+      "renderer.*",
+      "node_modules/**/*",
+      "package.json"
+    ],
     "mac": {
       "category": "public.app-category.graphics-design"
     },


### PR DESCRIPTION
This pull request contains two commits fixing the issue #56.
The bug was introduced with v0.5.0 because the images were moved from the `./images` to the `./build` directory. This only changes the behavior on Linux, since the icon is not set on other platforms.